### PR TITLE
Implement delete recording API

### DIFF
--- a/Controller/Adminhtml/Recording/Delete.php
+++ b/Controller/Adminhtml/Recording/Delete.php
@@ -15,6 +15,7 @@ use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Mageproxy\Connector\Api\RecordingManagerInterface;
 use Mageproxy\Connector\Api\RecordingRepositoryInterface;
 
 class Delete extends Action implements HttpGetActionInterface
@@ -22,13 +23,16 @@ class Delete extends Action implements HttpGetActionInterface
     const ADMIN_RESOURCE = 'Mageproxy_Connector::recording_delete';
 
     private RecordingRepositoryInterface $recordingRepository;
+    private RecordingManagerInterface $recordingManager;
 
     public function __construct(
         Context $context,
-        RecordingRepositoryInterface $recordingRepository
+        RecordingRepositoryInterface $recordingRepository,
+        RecordingManagerInterface $recordingManager
     ) {
         parent::__construct($context);
         $this->recordingRepository = $recordingRepository;
+        $this->recordingManager = $recordingManager;
     }
 
     public function execute()
@@ -36,7 +40,8 @@ class Delete extends Action implements HttpGetActionInterface
         $id = (int) $this->getRequest()->getParam('id');
 
         try {
-            $this->recordingRepository->deleteById($id);
+            $recording = $this->recordingRepository->getById($id);
+            $this->recordingManager->delete($recording);
         } catch (CouldNotDeleteException|NoSuchEntityException $e) {
             $this->messageManager->addErrorMessage(__('An error occurred while deleting the recording.'));
             return $this->_redirect('*/*/');

--- a/Controller/Adminhtml/Recording/MassDelete.php
+++ b/Controller/Adminhtml/Recording/MassDelete.php
@@ -19,6 +19,7 @@ use Magento\Framework\View\Result\PageFactory;
 use Magento\Ui\Component\MassAction\Filter;
 use Mageproxy\Connector\Api\Data\OptimizationInterface;
 use Mageproxy\Connector\Api\OptimizationRepositoryInterface;
+use Mageproxy\Connector\Api\RecordingManagerInterface;
 use Mageproxy\Connector\Api\RecordingRepositoryInterface;
 use Mageproxy\Connector\Model\ResourceModel\Recording\CollectionFactory;
 
@@ -27,6 +28,7 @@ class MassDelete extends Action implements HttpPostActionInterface
     public const ADMIN_RESOURCE = 'Mageproxy_Connector::recording_delete';
 
     private RecordingRepositoryInterface $recordingRepository;
+    private RecordingManagerInterface $recordingManager;
     private Filter $filter;
     private CollectionFactory $collectionFactory;
     private OptimizationRepositoryInterface $optimizationRepository;
@@ -36,6 +38,7 @@ class MassDelete extends Action implements HttpPostActionInterface
     public function __construct(
         Context $context,
         RecordingRepositoryInterface $recordingRepository,
+        RecordingManagerInterface $recordingManager,
         Filter $filter,
         CollectionFactory $collectionFactory,
         PageFactory $resultFactory,
@@ -45,6 +48,7 @@ class MassDelete extends Action implements HttpPostActionInterface
     ) {
         parent::__construct($context);
         $this->recordingRepository = $recordingRepository;
+        $this->recordingManager = $recordingManager;
         $this->filter = $filter;
         $this->collectionFactory = $collectionFactory;
         $this->resultFactory = $resultFactory;
@@ -84,7 +88,7 @@ class MassDelete extends Action implements HttpPostActionInterface
                 );
                 continue;
             }
-            $this->recordingRepository->deleteById($id);
+            $this->recordingManager->delete($recording);
             $deleteCnt++;
         }
 

--- a/Model/ApiClient/PostDeleteRecording.php
+++ b/Model/ApiClient/PostDeleteRecording.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Mageproxy Connector for Magento2.
+ *
+ * @package    Mageproxy_Connector
+ * @copyright  Copyright (c) 2025 Iframe Co Ltd
+ * @license    See LICENSE.txt for license details
+ */
+declare(strict_types=1);
+
+namespace Mageproxy\Connector\Model\ApiClient;
+
+class PostDeleteRecording implements PostDeleteRecordingInterface
+{
+    private Adapter $adapter;
+
+    public function __construct(
+        Adapter $adapter
+    ) {
+        $this->adapter = $adapter;
+    }
+
+    public function execute(string $recordingId): void
+    {
+        $this->adapter->post(null, ['id' => $recordingId]);
+    }
+}

--- a/Model/ApiClient/PostDeleteRecordingInterface.php
+++ b/Model/ApiClient/PostDeleteRecordingInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Mageproxy Connector for Magento2.
+ *
+ * @package    Mageproxy_Connector
+ * @copyright  Copyright (c) 2025 Iframe Co Ltd
+ * @license    See LICENSE.txt for license details
+ */
+declare(strict_types=1);
+
+namespace Mageproxy\Connector\Model\ApiClient;
+
+interface PostDeleteRecordingInterface
+{
+    /**
+     * @param string $recordingId
+     * @return void
+     */
+    public function execute(string $recordingId): void;
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -31,6 +31,7 @@ class Config
     public const XML_PATH_API_PATH_GET_SERVICE = 'mageproxy_connector/settings/api_path_get_service';
     public const XML_PATH_API_PATH_GET_OPTIMIZATION = 'mageproxy_connector/settings/api_path_get_optimization';
     public const XML_PATH_API_PATH_NEW_RECORDING = 'mageproxy_connector/settings/api_path_new_recording';
+    public const XML_PATH_API_PATH_POST_RECORDING_DELETE = 'mageproxy_connector/settings/api_path_post_recording_delete';
     public const XML_PATH_API_PATH_RECORDING_OPTIMIZE = 'mageproxy_connector/settings/api_path_recording_optimize';
     public const XML_PATH_API_PATH_OAUTH_TOKEN = 'mageproxy_connector/settings/api_path_oauth_token';
     public const XML_PATH_API_PATH_POST_OPTIMIZATION_DEPLOY = 'mageproxy_connector/settings/api_path_post_optimization_deploy';

--- a/Model/RecordingManager.php
+++ b/Model/RecordingManager.php
@@ -29,10 +29,12 @@ use Mageproxy\Connector\Model\Recording\Source\Status;
 use Mageproxy\Connector\Model\ResourceModel\Dependency\CollectionFactory;
 use Mageproxy\Connector\Model\System\Config\Source\AutoRunType;
 use Mageproxy\Connector\Model\System\Config\Source\RunMode;
+use Mageproxy\Connector\Model\ApiClient\PostDeleteRecordingInterface;
 
 class RecordingManager implements RecordingManagerInterface
 {
     private RecordingRepositoryInterface $recordingRepository;
+    private PostDeleteRecordingInterface $deleteRecordingApiClient;
     private Status $statusOptions;
     private StoreManagerInterface $storeManager;
     private SearchCriteriaBuilder $searchCriteriaBuilder;
@@ -61,7 +63,8 @@ class RecordingManager implements RecordingManagerInterface
         AutoRunScheduleFactory $autoRunScheduleFactory,
         CollectionFactory $dependencyCollectionFactory,
         GetRecordingJsDepsCountInterface $getRecordingJsDepsCountApiClient,
-        GetRecordingSnapshotInterface $getRecordingSnapshotApiClient
+        GetRecordingSnapshotInterface $getRecordingSnapshotApiClient,
+        PostDeleteRecordingInterface $deleteRecordingApiClient
     ) {
         $this->recordingRepository = $recordingRepository;
         $this->statusOptions = $statusOptions;
@@ -77,6 +80,7 @@ class RecordingManager implements RecordingManagerInterface
         $this->dependencyCollectionFactory = $dependencyCollectionFactory;
         $this->getRecordingJsDepsCountApiClient = $getRecordingJsDepsCountApiClient;
         $this->getRecordingSnapshotApiClient = $getRecordingSnapshotApiClient;
+        $this->deleteRecordingApiClient = $deleteRecordingApiClient;
     }
 
     /**
@@ -269,6 +273,28 @@ class RecordingManager implements RecordingManagerInterface
         }
         $recording->setStatus(RecordingInterface::STATUS_FINISHED);
         $this->recordingRepository->save($recording);
+        try {
+            $this->deleteRecordingApiClient->execute($recording->getUuid());
+        } catch (\Exception $e) {
+            // Might throw if recording already deleted
+        }
+    }
+
+    /**
+     * Deletes a recording.
+     *
+     * @param RecordingInterface $recording
+     * @return void
+     */
+    public function delete(RecordingInterface $recording): void
+    {
+        $uuid = $recording->getUuid();
+        $this->recordingRepository->delete($recording);
+        try {
+            $this->deleteRecordingApiClient->execute($uuid);
+        } catch (\Exception $e) {
+            // Might throw if recording already deleted
+        }
     }
 
     /**

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,6 +16,7 @@
                 <api_token backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <api_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <api_path_new_recording>/v1/services/:id/record</api_path_new_recording>
+                <api_path_post_recording_delete>/v1/recordings/:id/delete</api_path_post_recording_delete>
                 <api_path_recording_deps>/v1/recordings/:id/handles/deps</api_path_recording_deps>
                 <api_path_recording_deps_cnt_ts>/v1/recordings/:id/deps/ts</api_path_recording_deps_cnt_ts>
                 <api_path_recording_deps_cnt>/v1/recordings/:id/deps/cnt</api_path_recording_deps_cnt>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -29,6 +29,7 @@
     <preference for="Mageproxy\Connector\Model\ApiClient\PostNewRecordingInterface" type="Mageproxy\Connector\Model\ApiClient\PostNewRecording"/>
     <preference for="Mageproxy\Connector\Model\ApiClient\PostNewRecordingResponseInterface" type="Mageproxy\Connector\Model\ApiClient\PostNewRecordingResponse"/>
     <preference for="Mageproxy\Connector\Model\ApiClient\PostNewRecordingRequestInterface" type="Mageproxy\Connector\Model\ApiClient\PostNewRecordingRequest"/>
+    <preference for="Mageproxy\Connector\Model\ApiClient\PostDeleteRecordingInterface" type="Mageproxy\Connector\Model\ApiClient\PostDeleteRecording"/>
     <preference for="Mageproxy\Connector\Model\ApiClient\GetOptimizationInterface" type="Mageproxy\Connector\Model\ApiClient\GetOptimization"/>
     <preference for="Mageproxy\Connector\Model\ApiClient\GetOptimizationResponseInterface" type="Mageproxy\Connector\Model\ApiClient\GetOptimizationResponse"/>
     <preference for="Mageproxy\Connector\Model\ApiClient\DistributionInterface" type="Mageproxy\Connector\Model\ApiClient\Distribution"/>
@@ -90,6 +91,11 @@
         <arguments>
             <argument name="responseFactory" xsi:type="object">PostRecordingResponseFactory</argument>
             <argument name="endpointConfigPath" xsi:type="const">Mageproxy\Connector\Model\Config::XML_PATH_API_PATH_NEW_RECORDING</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="PostDeleteRecordingAdapter" type="Mageproxy\Connector\Model\ApiClient\Adapter">
+        <arguments>
+            <argument name="endpointConfigPath" xsi:type="const">Mageproxy\Connector\Model\Config::XML_PATH_API_PATH_POST_RECORDING_DELETE</argument>
         </arguments>
     </virtualType>
     <virtualType name="GetRecordingJsDepsAdapter" type="Mageproxy\Connector\Model\ApiClient\Adapter">
@@ -170,6 +176,11 @@
     <type name="Mageproxy\Connector\Model\ApiClient\PostNewRecording">
         <arguments>
             <argument name="adapter" xsi:type="object">PostNewRecordingAdapter</argument>
+        </arguments>
+    </type>
+    <type name="Mageproxy\Connector\Model\ApiClient\PostDeleteRecording">
+        <arguments>
+            <argument name="adapter" xsi:type="object">PostDeleteRecordingAdapter</argument>
         </arguments>
     </type>
     <type name="Mageproxy\Connector\Model\ApiClient\GetOptimization">


### PR DESCRIPTION
  The changes include:
   - Modifications to Delete.php and MassDelete.php to use the RecordingManager for deleting recordings.
   - A new PostDeleteRecording.php and its interface to handle deleting recordings via the API.
   - Configuration changes in config.xml and di.xml to support the new API endpoint.
   - Updates to RecordingManager.php to call the new delete recording API endpoint.